### PR TITLE
Handle beta deployment statuses

### DIFF
--- a/lib/messages/deployment-status.js
+++ b/lib/messages/deployment-status.js
@@ -34,6 +34,16 @@ class DeploymentStatus extends Message {
         fallback: `[${this.repository.full_name}] Deploying ${center}`,
         text: `Deploying ${centerWithLink}`,
       };
+    } else if (this.deploymentStatus.state == 'in_progress') {
+      return {
+        fallback: `[$(this.repository.full_name}] Deployment in progress for ${center}`,
+        text: `Deployment in progress ${centerWithLink}`
+      };
+    } else if (this.deploymentStatus.state == 'queued') {
+      return {
+        fallback: `[$(this.repository.full_name}] Deployment queued for ${center}`,
+        text: `Deployment queued ${centerWithLink}`
+      };
     } else if (this.deploymentStatus.state === 'success') {
       return {
         fallback: `[${this.repository.full_name}] Successfully deployed ${center}`,


### PR DESCRIPTION
👋 

This improves how deployments in the two new beta statuses (`queued` and `in_progress`) are displayed. More information available about these statuses in the [Deployment Status documentation](https://developer.github.com/v3/repos/deployments/#create-a-deployment-status).

## TODO

- [ ] Add test cases
- [ ] Add these cases in `State.getStatusColor`